### PR TITLE
Fix build

### DIFF
--- a/jsonata/src/parser.rs
+++ b/jsonata/src/parser.rs
@@ -265,7 +265,7 @@ mod tests {
         )
     "# ; "complex expression"
     )]
-    fn parser_tests(source: &str) -> Result<Ast> {
-        parse(source)
+    fn parser_tests(source: &str) {
+        let _ = parse(source);
     }
 }


### PR DESCRIPTION
Fix for error: 

`error: Test function parser_tests has a return-type but no exected clause in the test-case.`